### PR TITLE
Fix dependencies

### DIFF
--- a/fluent-plugin-referer-parser.gemspec
+++ b/fluent-plugin-referer-parser.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'rake'
-  gem.add_runtime_dependency 'fluentd'
-  gem.add_runtime_dependency 'referer-parser', '>= 0.2.0'
+  gem.add_development_dependency 'test-unit', '>= 3.2'
+  gem.add_runtime_dependency 'fluentd', '~> 0.12.0'
+  gem.add_runtime_dependency 'referer-parser', '~> 0.2.0'
 end

--- a/test/plugin/test_out_referer_parser.rb
+++ b/test/plugin/test_out_referer_parser.rb
@@ -30,6 +30,10 @@ referers_yaml test/data/referers.yaml
 encodings_yaml test/data/encodings.yaml
 )
 
+  def setup
+    Fluent::Test.setup
+  end
+
   def create_driver(conf = CONFIG1, tag = 'test')
     Fluent::Test::OutputTestDriver.new(Fluent::RefererParserOutput, tag).configure(conf)
   end


### PR DESCRIPTION
* Add missing dependency test-unit because test-unit is not bundled
 with Ruby
* Fix version dependency for fluentd because Fluentd v0.14.x does not
 support `Fluent::Engine.emit`
* Fix version dependency for referer-parser because referer-parser
 0.3.0 changes API